### PR TITLE
adds split str util, adds classes to Element

### DIFF
--- a/includes/yahtml/DOM.hh
+++ b/includes/yahtml/DOM.hh
@@ -20,6 +20,7 @@ struct Element;
 
 typedef std::shared_ptr<Node> DOMChild;
 typedef std::vector<DOMChild> DOMChildren;
+typedef std::vector<std::string> DOMClasses;
 
 struct Attr : std::pair<std::string, std::string>
 {
@@ -60,9 +61,12 @@ class Element : public Node
 {
 public:
   std::string tag_name;
+  DOMClasses classes;
   AttrMap attr_map;
 
-  Element(std::string name, AttrMap attrs, DOMChildren dc = DOMChildren {});
+  Element(std::string name, AttrMap attrs,
+          DOMChildren dc = DOMChildren {},
+          DOMClasses classes = DOMClasses {});
 
   void print(std::ostream& where, int ident) const override;
 };

--- a/includes/yahtml/Utils.hh
+++ b/includes/yahtml/Utils.hh
@@ -1,0 +1,33 @@
+#ifndef YAHTML__UTILS__UTILS_HH
+#define YAHTML__UTILS__UTILS_HH 1
+
+#include <vector>
+#include <string>
+#include <algorithm>
+
+namespace yahtml { namespace utils {
+
+inline std::vector<std::string> split_str (const std::string& str,
+                                           int delimiter(int) = ::isspace)
+{
+  std::vector<std::string> result;
+  std::string::const_iterator end = str.end();
+  std::string::const_iterator i = str.begin();
+  std::string::const_iterator j;
+
+  while (i != end) {
+    i = std::find_if_not(i, end, delimiter);
+    if (i == end)
+      break;
+
+    j = find_if(i, end, delimiter);
+    result.push_back(std::string(i, j));
+    i = j;
+  }
+
+  return result;
+}
+
+}}; // ! ns yahtml utils
+
+#endif

--- a/src/DOM.cc
+++ b/src/DOM.cc
@@ -20,8 +20,10 @@ std::ostream& operator<<(std::ostream& o, const Node& node)
 }
 
 
-Element::Element(std::string name, AttrMap attrs, DOMChildren dc)
-  : Node(NodeType::Element, dc), tag_name(name), attr_map(attrs)
+Element::Element(std::string name, AttrMap attrs,
+                 DOMChildren dc, DOMClasses klasses)
+  : Node(NodeType::Element, dc), tag_name(name), attr_map(attrs),
+    classes(klasses)
 { }
 
 void Element::print(std::ostream& where, int ident) const

--- a/tests/parser_test.cc
+++ b/tests/parser_test.cc
@@ -156,3 +156,44 @@ TEST(Html, NestedMultipleAttributes) {
   EXPECT_EQ(text->text, "huehue brbr");
 }
 
+TEST(Html, EmptyClassAttribute) {
+  bool debug = false;
+  HTMLDriver driver(debug, debug);
+  const char* source =
+    "<body class=\"\">"
+    "</body>"
+    "";
+  driver.parse_source(source);
+
+  EXPECT_EQ(driver.dom.get()->type, NodeType::Element);
+
+  Element* body = dynamic_cast<Element*>(driver.dom.get());
+
+  EXPECT_EQ(body->tag_name, "body");
+  EXPECT_EQ(body->attr_map.size(), 1);
+  EXPECT_EQ(body->attr_map["class"], "");
+  EXPECT_EQ(body->classes.size(), 0);
+}
+
+TEST(Html, MultipleClassesAttribute) {
+  bool debug = false;
+  HTMLDriver driver(debug, debug);
+  const char* source =
+    "<body class=\"hue br lol\">"
+    "</body>"
+    "";
+  driver.parse_source(source);
+
+  EXPECT_EQ(driver.dom.get()->type, NodeType::Element);
+
+  Element* body = dynamic_cast<Element*>(driver.dom.get());
+
+  EXPECT_EQ(body->tag_name, "body");
+  EXPECT_EQ(body->attr_map.size(), 1);
+  EXPECT_EQ(body->attr_map["class"], "hue br lol");
+
+  EXPECT_EQ(body->classes[0], "hue");
+  EXPECT_EQ(body->classes[1], "br");
+  EXPECT_EQ(body->classes[2], "lol");
+}
+


### PR DESCRIPTION
at parse-time populates `.classes` so that we are able to perform selector matching in a better way in `yabrowser`. It might also be useful for other stuff in the future.
